### PR TITLE
Bitnami ARM64 Workaround

### DIFF
--- a/helm/mitre-siphon/Chart.yaml
+++ b/helm/mitre-siphon/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: mitre-siphon
 description: A full text search of the mitre CVE database
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "0.1.0"
 maintainers:
   - name: bryopsida

--- a/helm/mitre-siphon/README.md
+++ b/helm/mitre-siphon/README.md
@@ -1,6 +1,6 @@
 # mitre-siphon
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.0](https://img.shields.io/badge/AppVersion-0.1.0-informational?style=flat-square)
 
 A full text search of the mitre CVE database
 
@@ -43,11 +43,14 @@ A full text search of the mitre CVE database
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
 | kafka.enabled | bool | `true` |  |
+| kafka.nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
+| kafka.zookeeper.nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | postgresql.enabled | bool | `true` |  |
+| postgresql.nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
 | probes.enabled | bool | `true` |  |
 | probes.live.enabled | bool | `true` |  |
 | probes.live.endpoint | string | `"/actuator/health"` |  |

--- a/helm/mitre-siphon/values.yaml
+++ b/helm/mitre-siphon/values.yaml
@@ -56,6 +56,11 @@ tolerations: []
 affinity: {}
 kafka:
   enabled: true
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  zookeeper:
+    nodeSelector:
+      kubernetes.io/arch: amd64
 global:
   postgresql:
     auth:
@@ -66,6 +71,8 @@ global:
       database: mitre
 postgresql:
   enabled: true
+  nodeSelector:
+      kubernetes.io/arch: amd64
 probes:
   enabled: true
   ready:


### PR DESCRIPTION
What
---
To handle running in mixed clusters where arm64 and amd64 nodes are present, set node selectors for the bitnami components which only function on amd64 for now. Hopefully bitnami eventually releases arm64 support.