### PR TITLE
136 - fix swagger 404

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ sourceCompatibility = '17'
 targetCompatibility = '17'
 
 ext {
-	springDocVersion = "1.6.13"
+	springDocVersion = "2.0.0"
 	mitreTaxiiVersion = '1.1.0.1'
 	mitreStixVersion = '1.2.0.2'
 	junitVersion = '5.9.1'
@@ -58,8 +58,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'org.springframework.boot:spring-boot-starter-quartz'
-	implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: springDocVersion
-	implementation group: 'org.springdoc', name: 'springdoc-openapi-security', version: springDocVersion
+	implementation group: 'org.springdoc', name: 'springdoc-openapi', version: springDocVersion
+	implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: springDocVersion
 	implementation group: 'org.mitre.taxii', name: 'taxii', version: mitreTaxiiVersion
 	implementation group: 'org.mitre', name: 'stix', version: mitreStixVersion
 	implementation group: 'javax.persistence', name: 'javax.persistence-api', version: javaxPersistenceVersion

--- a/src/main/java/rocks/curium/mitresiphon/actors/CveArchiver.java
+++ b/src/main/java/rocks/curium/mitresiphon/actors/CveArchiver.java
@@ -2,7 +2,6 @@ package rocks.curium.mitresiphon.actors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -10,7 +9,6 @@ import org.springframework.stereotype.Component;
 import rocks.curium.mitresiphon.dao.interfaces.CVEDAO;
 import rocks.curium.mitresiphon.entities.CVE;
 import rocks.curium.mitresiphon.generated.models.Def_cve_item;
-import rocks.curium.mitresiphon.generated.models.Nvd_cve_feed_json_1_1;
 import rocks.curium.mitresiphon.tasks.NVDFetchTask;
 
 @Component
@@ -24,17 +22,17 @@ public class CveArchiver {
     cveDao = dao;
   }
 
-  private Nvd_cve_feed_json_1_1 deserialize(String jsonStr) throws JsonProcessingException {
-    return MAPPER.readValue(jsonStr, Nvd_cve_feed_json_1_1.class);
+  private Def_cve_item deserialize(String jsonStr) throws JsonProcessingException {
+    return MAPPER.readValue(jsonStr, Def_cve_item.class);
   }
 
   @KafkaListener(topics = NVDFetchTask.MODIFIED_KAFKA_TOPIC, groupId = "cve-pg-archiver-group")
   public void handleModifiedCve(String modifiedCveUpdate) {
     LOG.debug("Received modified cve update");
     try {
-      Nvd_cve_feed_json_1_1 update = deserialize(modifiedCveUpdate);
-      LOG.info("Processing modified cve update with {} records", update.getCVE_Items().size());
-      insertMissingCves(update.getCVE_Items());
+      final Def_cve_item update = deserialize(modifiedCveUpdate);
+      LOG.debug("Processing modified cve update");
+      track(update);
     } catch (JsonProcessingException e) {
       LOG.error("error while processing modified cve message {}", e.getMessage());
     }
@@ -44,9 +42,9 @@ public class CveArchiver {
   public void handleRecentCve(String recentCveUpdate) {
     LOG.debug("Received recent cve update");
     try {
-      Nvd_cve_feed_json_1_1 update = deserialize(recentCveUpdate);
-      LOG.info("Processing recent cve update with {} records", update.getCVE_Items().size());
-      insertMissingCves(update.getCVE_Items());
+      final Def_cve_item update = deserialize(recentCveUpdate);
+      LOG.debug("Processing recent cve update");
+      track(update);
     } catch (JsonProcessingException e) {
       LOG.error("error while processing recent cve message {}", e.getMessage());
     }
@@ -56,30 +54,27 @@ public class CveArchiver {
   public void handleCompleteCve(String completeCveUpdate) {
     LOG.debug("Received complete cve update");
     try {
-      Nvd_cve_feed_json_1_1 update = deserialize(completeCveUpdate);
-      LOG.info("Processing recent cve update with {} records", update.getCVE_Items().size());
-      insertMissingCves(update.getCVE_Items());
+      Def_cve_item update = deserialize(completeCveUpdate);
+      LOG.debug("Processing complete cve update");
+      track(update);
     } catch (JsonProcessingException e) {
       LOG.error("error while processing complete cve message {}", e.getMessage());
     }
   }
 
-  private void insertMissingCves(List<Def_cve_item> cves) {
-    cves.forEach(
-        a -> {
-          if (!cveDao.isCveTracked(a.getCve().getCVE_data_meta().getID().toLowerCase())) {
-            var newCve = new CVE();
-            var nvdCve = a.getCve();
-            if (!nvdCve.getDescription().getDescription_data().isEmpty()) {
-              newCve.setDescription(
-                  nvdCve.getDescription().getDescription_data().get(0).getValue());
-            }
-            newCve.setId(nvdCve.getCVE_data_meta().getID());
-            if (!nvdCve.getReferences().getReference_data().isEmpty()) {
-              newCve.setReferences(nvdCve.getReferences().getReference_data().get(0).getUrl());
-            }
-            cveDao.save(newCve);
-          }
-        });
+  private void track(final Def_cve_item a) {
+      if (!cveDao.isCveTracked(a.getCve().getCVE_data_meta().getID().toLowerCase())) {
+        var newCve = new CVE();
+        var nvdCve = a.getCve();
+        if (!nvdCve.getDescription().getDescription_data().isEmpty()) {
+          newCve.setDescription(
+              nvdCve.getDescription().getDescription_data().get(0).getValue());
+        }
+        newCve.setId(nvdCve.getCVE_data_meta().getID());
+        if (!nvdCve.getReferences().getReference_data().isEmpty()) {
+          newCve.setReferences(nvdCve.getReferences().getReference_data().get(0).getUrl());
+        }
+        cveDao.save(newCve);
+      }
   }
 }

--- a/src/main/java/rocks/curium/mitresiphon/actors/CveArchiver.java
+++ b/src/main/java/rocks/curium/mitresiphon/actors/CveArchiver.java
@@ -63,18 +63,17 @@ public class CveArchiver {
   }
 
   private void track(final Def_cve_item a) {
-      if (!cveDao.isCveTracked(a.getCve().getCVE_data_meta().getID().toLowerCase())) {
-        var newCve = new CVE();
-        var nvdCve = a.getCve();
-        if (!nvdCve.getDescription().getDescription_data().isEmpty()) {
-          newCve.setDescription(
-              nvdCve.getDescription().getDescription_data().get(0).getValue());
-        }
-        newCve.setId(nvdCve.getCVE_data_meta().getID());
-        if (!nvdCve.getReferences().getReference_data().isEmpty()) {
-          newCve.setReferences(nvdCve.getReferences().getReference_data().get(0).getUrl());
-        }
-        cveDao.save(newCve);
+    if (!cveDao.isCveTracked(a.getCve().getCVE_data_meta().getID().toLowerCase())) {
+      var newCve = new CVE();
+      var nvdCve = a.getCve();
+      if (!nvdCve.getDescription().getDescription_data().isEmpty()) {
+        newCve.setDescription(nvdCve.getDescription().getDescription_data().get(0).getValue());
       }
+      newCve.setId(nvdCve.getCVE_data_meta().getID());
+      if (!nvdCve.getReferences().getReference_data().isEmpty()) {
+        newCve.setReferences(nvdCve.getReferences().getReference_data().get(0).getUrl());
+      }
+      cveDao.save(newCve);
+    }
   }
 }

--- a/src/main/java/rocks/curium/mitresiphon/dao/CVEDAOImpl.java
+++ b/src/main/java/rocks/curium/mitresiphon/dao/CVEDAOImpl.java
@@ -45,7 +45,7 @@ public class CVEDAOImpl extends BaseDaoImpl<CVE> implements CVEDAO {
     query.setParameter("offset", criteria.getOffset());
 
     var result = new SearchResult();
-    result.setTotalMatches((BigInteger) countQuery.uniqueResult());
+    result.setTotalMatches(BigInteger.valueOf((Long) countQuery.uniqueResult()));
     result.setMatches(query.stream().collect(Collectors.toList()));
     result.setOffset(criteria.getOffset());
     result.setCount(criteria.getCount());

--- a/src/main/java/rocks/curium/mitresiphon/tasks/NVDFetchTask.java
+++ b/src/main/java/rocks/curium/mitresiphon/tasks/NVDFetchTask.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.concurrent.ExecutionException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
@@ -13,6 +15,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 import rocks.curium.mitresiphon.dao.interfaces.ResourceStatDAO;
+import rocks.curium.mitresiphon.generated.models.CVE_JSON_4_0_min_1_1;
+import rocks.curium.mitresiphon.generated.models.Def_cve_item;
+import rocks.curium.mitresiphon.generated.models.Nvd_cve_feed_json_1_1;
 import rocks.curium.mitresiphon.tasks.helpers.interfaces.HttpModifiedCheck;
 import rocks.curium.mitresiphon.tasks.helpers.interfaces.NvdHttpFetch;
 
@@ -24,6 +29,7 @@ public class NVDFetchTask extends QuartzJobBean {
   private final HttpModifiedCheck modifiedCheck;
   private final NvdHttpFetch fetcher;
   private final ResourceStatDAO resourceDAO;
+  private final ObjectMapper mapper;
 
   private static final Logger LOG = LoggerFactory.getLogger(NVDFetchTask.class);
 
@@ -32,7 +38,7 @@ public class NVDFetchTask extends QuartzJobBean {
   public static final String RECENT_URL =
       "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-recent.json.gz";
   public static final String COMPLETE_URL =
-      "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2021.json.gz";
+      "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2022.json.gz";
 
   public static final String URL_PARM_NAME = "NVD_FETCH_URL";
   public static final String KAFKA_TOPIC_PARM_NAME = "NVD_PUBLISH_TARGET";
@@ -55,13 +61,17 @@ public class NVDFetchTask extends QuartzJobBean {
     modifiedCheck = modCheck;
     fetcher = nvdHttpFetch;
     resourceDAO = resource;
+    mapper = new ObjectMapper();
   }
 
   private boolean checkAndPublish(URI resourceUri, ZonedDateTime lastFetchTime, String topic)
       throws IOException, ExecutionException, InterruptedException {
     if (Boolean.TRUE.equals(modifiedCheck.isNewDataAvailable(lastFetchTime, resourceUri).get())) {
       String feedResponse = fetcher.fetch(resourceUri).get();
-      kafkaTemplate.send(topic, feedResponse);
+      final Nvd_cve_feed_json_1_1 db = mapper.readValue(feedResponse, Nvd_cve_feed_json_1_1.class);
+      for(final Def_cve_item item: db.getCVE_Items()) {
+        kafkaTemplate.send(topic, mapper.writeValueAsString(item));
+      }
       return true;
     } else {
       return false;

--- a/src/main/java/rocks/curium/mitresiphon/tasks/NVDFetchTask.java
+++ b/src/main/java/rocks/curium/mitresiphon/tasks/NVDFetchTask.java
@@ -1,11 +1,10 @@
 package rocks.curium.mitresiphon.tasks;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.concurrent.ExecutionException;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.quartz.DisallowConcurrentExecution;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
@@ -15,7 +14,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.scheduling.quartz.QuartzJobBean;
 import rocks.curium.mitresiphon.dao.interfaces.ResourceStatDAO;
-import rocks.curium.mitresiphon.generated.models.CVE_JSON_4_0_min_1_1;
 import rocks.curium.mitresiphon.generated.models.Def_cve_item;
 import rocks.curium.mitresiphon.generated.models.Nvd_cve_feed_json_1_1;
 import rocks.curium.mitresiphon.tasks.helpers.interfaces.HttpModifiedCheck;
@@ -69,7 +67,7 @@ public class NVDFetchTask extends QuartzJobBean {
     if (Boolean.TRUE.equals(modifiedCheck.isNewDataAvailable(lastFetchTime, resourceUri).get())) {
       String feedResponse = fetcher.fetch(resourceUri).get();
       final Nvd_cve_feed_json_1_1 db = mapper.readValue(feedResponse, Nvd_cve_feed_json_1_1.class);
-      for(final Def_cve_item item: db.getCVE_Items()) {
+      for (final Def_cve_item item : db.getCVE_Items()) {
         kafkaTemplate.send(topic, mapper.writeValueAsString(item));
       }
       return true;

--- a/src/main/java/rocks/curium/mitresiphon/tasks/helpers/HttpModifiedCheckImpl.java
+++ b/src/main/java/rocks/curium/mitresiphon/tasks/helpers/HttpModifiedCheckImpl.java
@@ -1,12 +1,14 @@
 package rocks.curium.mitresiphon.tasks.helpers;
 
 import java.net.URI;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.Disposable;
+import reactor.netty.http.client.HttpClientRequest;
 import rocks.curium.mitresiphon.tasks.helpers.interfaces.HttpModifiedCheck;
 
 @Service
@@ -35,6 +37,11 @@ public class HttpModifiedCheckImpl implements HttpModifiedCheck {
             .build()
             .head()
             .uri(resourceUri)
+            .httpRequest(
+                httpRequest -> {
+                  HttpClientRequest reactorRequest = httpRequest.getNativeRequest();
+                  reactorRequest.responseTimeout(Duration.ofSeconds(10));
+                })
             .exchangeToFlux(
                 clientResponse -> {
                   clientResponse.headers();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,4 +24,4 @@ spring.quartz.properties.org.quartz.jobStore.isClustered=true
 spring.quartz.properties.scheduler.jmx.export=true
 spring.quartz.properties.jobStore.clusterCheckinInterval=20000
 springdoc.swagger-ui.path=/swagger-ui.html
-logging.level.root=DEBUG
+logging.level.root=INFO

--- a/src/test/java/rocks/curium/mitresiphon/actors/CveArchiverTests.java
+++ b/src/test/java/rocks/curium/mitresiphon/actors/CveArchiverTests.java
@@ -16,7 +16,7 @@ class CveArchiverTests {
 
   private String serialize(Nvd_cve_feed_json_1_1 feed) throws JsonProcessingException {
     ObjectMapper mapper = new ObjectMapper();
-    return mapper.writeValueAsString(feed);
+    return mapper.writeValueAsString(feed.getCVE_Items().get(0));
   }
 
   private Nvd_cve_feed_json_1_1 getFeed() {

--- a/src/test/java/rocks/curium/mitresiphon/tasks/NVDFetchTaskTests.java
+++ b/src/test/java/rocks/curium/mitresiphon/tasks/NVDFetchTaskTests.java
@@ -62,12 +62,12 @@ class NVDFetchTaskTests {
     testMap.put(NVDFetchTask.URL_PARM_NAME, resourceUri.toString());
     testMap.put(NVDFetchTask.KAFKA_TOPIC_PARM_NAME, "TEST");
     Mockito.when(context.getMergedJobDataMap()).thenReturn(new JobDataMap(testMap));
-    Mockito.when(fetch.fetch(any())).thenReturn(CompletableFuture.completedFuture("TEST"));
+    Mockito.when(fetch.fetch(any())).thenReturn(CompletableFuture.completedFuture("{}"));
     NVDFetchTask fetchTask = new NVDFetchTask(kafkaTemplate, modifiedCheck, fetch, resourceDAO);
     fetchTask.executeInternal(context);
     // TODO: refactor to use awaitility to wait condition with timeout, execute doesn't return
     // future and code behind leverages futures
-    Thread.sleep(5000);
+    Thread.sleep(15000);
     Mockito.verify(fetch, times(1)).fetch(any());
   }
 }


### PR DESCRIPTION
What
---
Fixes a 404 error when using swagger ui by upgrading to springdoc version 2.0 as spring boot 3.0 is in use and 1.6 does not work with spring boot 3. Also adjust the publish pattern to publish individual CVEs into kafka instead of a large doc to deal with CVE DB sizes exceeding kafka buffer sizes for messages.